### PR TITLE
Refactor the WebKit side code to use a locked HashSet of animations t…

### DIFF
--- a/Source/WebCore/platform/animation/AcceleratedEffectStack.h
+++ b/Source/WebCore/platform/animation/AcceleratedEffectStack.h
@@ -45,11 +45,10 @@ class FloatRect;
 
 using AcceleratedEffects = Vector<Ref<AcceleratedEffect>>;
 
-class AcceleratedEffectStack {
-    WTF_MAKE_FAST_ALLOCATED;
+class AcceleratedEffectStackBase {
 public:
-    WEBCORE_EXPORT explicit AcceleratedEffectStack();
-    WEBCORE_EXPORT ~AcceleratedEffectStack();
+    WEBCORE_EXPORT explicit AcceleratedEffectStackBase();
+    WEBCORE_EXPORT ~AcceleratedEffectStackBase();
 
     WEBCORE_EXPORT bool hasEffects() const;
     const AcceleratedEffects& primaryLayerEffects() const { return m_primaryLayerEffects; }
@@ -59,20 +58,26 @@ public:
     const AcceleratedEffectValues& baseValues() { return m_baseValues; }
     WEBCORE_EXPORT void setBaseValues(const AcceleratedEffectValues&&);
     
-    WEBCORE_EXPORT void applyPrimaryLayerEffects(PlatformLayer *, Seconds);
+    WEBCORE_EXPORT void initAsyncEffects(PlatformLayer *, Seconds);
     WEBCORE_EXPORT void applyBackdropLayerEffects(PlatformLayer *, Seconds) const;
+    WEBCORE_EXPORT void applyEffectsAsync(const FloatRect&, Seconds) const;
     WEBCORE_EXPORT void clear(PlatformLayer *);
 
 private:
     AcceleratedEffectValues computeValues(const AcceleratedEffects&, Seconds, const FloatRect&) const;
 
+
     AcceleratedEffectValues m_baseValues;
     AcceleratedEffects m_primaryLayerEffects;
     AcceleratedEffects m_backdropLayerEffects;
-    
+
     RetainPtr<CAPresentationModifierGroup> m_presentationModifierGroup;
     RetainPtr<CAPresentationModifier> m_opacityPresentationModifier;
     RetainPtr<CAPresentationModifier> m_transformPresentationModifier;
+};
+
+class AcceleratedEffectStack : public AcceleratedEffectStackBase {
+    WTF_MAKE_FAST_ALLOCATED;
 };
 
 } // namespace WebCore

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1692,6 +1692,7 @@ enum class WebCore::ScrollSnapStrictness : uint8_t {
 
 enum class WebCore::LengthType : uint8_t {
     Auto,
+    Normal,
     Relative,
     Percent,
     Fixed,

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
@@ -62,8 +62,16 @@ public:
     TransactionID lastCommittedLayerTreeTransactionID() const { return m_webPageProxyProcessState.transactionIDForPendingCACommit; }
 
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
-    virtual void animationsDidChangeOnNode(RemoteLayerTreeNode&) = 0;
-    virtual void updateAnimations() = 0;
+    void animationEffectStackAdded(Ref<RemoteAcceleratedEffectStack> effects);
+    void animationEffectStackRemoved(Ref<RemoteAcceleratedEffectStack> effects);
+    Seconds acceleratedTimelineTimeOrigin() const
+    {
+        return m_acceleratedTimelineTimeOrigin;
+    }
+    Seconds animationCurrentTime() const
+    {
+        return m_animationCurrentTime;
+    }
 #endif
 
     virtual void didRefreshDisplay();
@@ -87,10 +95,6 @@ protected:
     void updateDebugIndicatorPosition();
 
     bool shouldCoalesceVisualEditorStateUpdates() const override { return true; }
-
-#if ENABLE(THREADED_ANIMATION_RESOLUTION)
-    bool hasAnimatedNodes() const;
-#endif
 
 private:
 
@@ -185,8 +189,8 @@ private:
     unsigned m_countOfTransactionsWithNonEmptyLayerChanges { 0 };
 
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
-    HashSet<RemoteLayerTreeNode*> m_animatedNodes;
     Seconds m_acceleratedTimelineTimeOrigin;
+    Seconds m_animationCurrentTime;
 #endif
 };
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
@@ -267,15 +267,16 @@ void RemoteLayerTreeDrawingAreaProxy::commitLayerTreeTransaction(IPC::Connection
 #endif
     };
 
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+    m_acceleratedTimelineTimeOrigin = layerTreeTransaction.acceleratedTimelineTimeOrigin();
+    m_animationCurrentTime = MonotonicTime::now().secondsSinceEpoch() -  m_acceleratedTimelineTimeOrigin;
+#endif
+
     webPageProxy->scrollingCoordinatorProxy()->willCommitLayerAndScrollingTrees();
     commitLayerAndScrollingTrees();
     webPageProxy->scrollingCoordinatorProxy()->didCommitLayerAndScrollingTrees();
 
     webPageProxy->didCommitLayerTree(layerTreeTransaction);
-
-#if ENABLE(THREADED_ANIMATION_RESOLUTION)
-    m_acceleratedTimelineTimeOrigin = layerTreeTransaction.acceleratedTimelineTimeOrigin();
-#endif
 
     didCommitLayerTree(connection, layerTreeTransaction, scrollingTreeTransaction);
 
@@ -606,30 +607,14 @@ void RemoteLayerTreeDrawingAreaProxy::sizeToContentAutoSizeMaximumSizeDidChange(
 }
 
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
-bool RemoteLayerTreeDrawingAreaProxy::hasAnimatedNodes() const
+void RemoteLayerTreeDrawingAreaProxy::animationEffectStackAdded(Ref<RemoteAcceleratedEffectStack> effects)
 {
-    return !m_animatedNodes.isEmpty();
+    protectedWebPageProxy()->scrollingCoordinatorProxy()->animationEffectStackAdded(WTFMove(effects));
 }
 
-void RemoteLayerTreeDrawingAreaProxy::animationsDidChangeOnNode(RemoteLayerTreeNode& node)
+void RemoteLayerTreeDrawingAreaProxy::animationEffectStackRemoved(Ref<RemoteAcceleratedEffectStack> effects)
 {
-    m_animatedNodes.add(&node);
-    LOG_WITH_STREAM(Animations, stream << "RemoteLayerTreeDrawingAreaProxy::animationsDidChangeOnNode() with " << m_animatedNodes.size() << "animated nodes");
-}
-
-void RemoteLayerTreeDrawingAreaProxy::updateAnimations()
-{
-    ASSERT(WebCore::ScrollingThread::isCurrentThread());
-
-    auto animatedNodes = std::exchange(m_animatedNodes, { });
-
-    LOG_WITH_STREAM(Animations, stream << "RemoteLayerTreeDrawingAreaProxy::updateAnimations() with " << animatedNodes.size() << "animated nodes");
-    auto currentTime = MonotonicTime::now().secondsSinceEpoch() - m_acceleratedTimelineTimeOrigin;
-    for (auto* node : animatedNodes) {
-        node->applyAnimatedEffectStack(currentTime);
-        if (node->hasAnimationEffects())
-            m_animatedNodes.add(node);
-    }
+    protectedWebPageProxy()->scrollingCoordinatorProxy()->animationEffectStackRemoved(WTFMove(effects));
 }
 #endif // ENABLE(THREADED_ANIMATION_RESOLUTION)
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h
@@ -68,7 +68,8 @@ public:
     void animationDidEnd(WebCore::PlatformLayerIdentifier, CAAnimation *);
 
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
-    void animationsDidChangeOnNode(RemoteLayerTreeNode&);
+    void animationEffectStackAdded(Ref<RemoteAcceleratedEffectStack>);
+    void animationEffectStackRemoved(Ref<RemoteAcceleratedEffectStack>);
 #endif
 
     void detachFromDrawingArea();
@@ -89,6 +90,9 @@ public:
     const HashSet<WebCore::PlatformLayerIdentifier>& overlayRegionIDs() const { return m_overlayRegionIDs; }
     void updateOverlayRegionIDs(const HashSet<WebCore::PlatformLayerIdentifier> &overlayRegionNodes) { m_overlayRegionIDs = overlayRegionNodes; }
 #endif
+
+    Seconds acceleratedTimelineTimeOrigin() const;
+    Seconds animationCurrentTime() const;
 private:
     void createLayer(const RemoteLayerTreeTransaction::LayerCreationProperties&);
     std::unique_ptr<RemoteLayerTreeNode> makeNode(const RemoteLayerTreeTransaction::LayerCreationProperties&);

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
@@ -306,9 +306,24 @@ void RemoteLayerTreeHost::animationDidEnd(WebCore::PlatformLayerIdentifier layer
 }
 
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
-void RemoteLayerTreeHost::animationsDidChangeOnNode(RemoteLayerTreeNode& node)
+void RemoteLayerTreeHost::animationEffectStackAdded(Ref<RemoteAcceleratedEffectStack> effects)
 {
-    m_drawingArea->animationsDidChangeOnNode(node);
+    m_drawingArea->animationEffectStackAdded(WTFMove(effects));
+}
+
+void RemoteLayerTreeHost::animationEffectStackRemoved(Ref<RemoteAcceleratedEffectStack> effects)
+{
+    m_drawingArea->animationEffectStackRemoved(WTFMove(effects));
+}
+
+Seconds RemoteLayerTreeHost::acceleratedTimelineTimeOrigin() const
+{
+    return m_drawingArea->acceleratedTimelineTimeOrigin();
+}
+
+Seconds RemoteLayerTreeHost::animationCurrentTime() const
+{
+    return m_drawingArea->animationCurrentTime();
 }
 #endif
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm
@@ -73,8 +73,8 @@ RemoteLayerTreeNode::RemoteLayerTreeNode(WebCore::PlatformLayerIdentifier layerI
 RemoteLayerTreeNode::~RemoteLayerTreeNode()
 {
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
-    if (m_effectStack)
-        m_effectStack->clear(layer());
+    if (m_effects)
+        m_effects->clear(layer());
 #endif
     [layer() setValue:nil forKey:WKRemoteLayerTreeNodePropertyKey];
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
@@ -248,9 +248,30 @@ NSString *RemoteLayerTreeNode::appendLayerDescription(NSString *description, CAL
 }
 
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
-void RemoteLayerTreeNode::setAcceleratedEffectsAndBaseValues(const WebCore::AcceleratedEffects& effects, const WebCore::AcceleratedEffectValues& baseValues)
+void RemoteLayerTreeNode::setAcceleratedEffectsAndBaseValues(const WebCore::AcceleratedEffects& effects, const WebCore::AcceleratedEffectValues& baseValues, RemoteLayerTreeHost* host)
 {
     ASSERT(isUIThread());
+    ASSERT(host);
+
+    if (m_effects) {
+        m_effects->clear(layer());
+        host->animationEffectStackRemoved(*m_effects);
+    }
+
+    if (effects.isEmpty())
+        return;
+
+    // We always recreate the effects stack to get a new CA
+    // presentation modifiers. Otherwise it's possible for the animation
+    // thread to tick and push values from the new animation onto the
+    // existing presentation modifier and have it applied before the rest
+    // of this transaction.
+    // Does that actually matter in practice?
+    // It does simplify things since these objects are effectively const,
+    // created here (and applied to the layer), and then we only ever recompute
+    // values and write those to the presentation modifiers async.
+    // Can we codify that 'constness' better?
+    m_effects = new RemoteAcceleratedEffectStack(layer().bounds, host->acceleratedTimelineTimeOrigin());
 
     WebCore::AcceleratedEffects clonedEffects;
     clonedEffects.reserveCapacity(effects.size());
@@ -259,39 +280,15 @@ void RemoteLayerTreeNode::setAcceleratedEffectsAndBaseValues(const WebCore::Acce
 
     auto clonedBaseValues = baseValues.clone();
 
-    // FIXME: need to keep the node alive.
-    WebCore::ScrollingThread::dispatch([this, clonedEffects = WTFMove(clonedEffects), clonedBaseValues = WTFMove(clonedBaseValues)] {
-        if (!m_effectStack)
-            m_effectStack = makeUnique<WebCore::AcceleratedEffectStack>();
+    m_effects->setEffects(WTFMove(clonedEffects));
+    m_effects->setBaseValues(WTFMove(clonedBaseValues));
 
-        m_effectStack->setEffects(WTFMove(clonedEffects));
-        m_effectStack->setBaseValues(WTFMove(clonedBaseValues));
-    });
-}
+    m_effects->initAsyncEffects(layer(), host->animationCurrentTime());
 
-bool RemoteLayerTreeNode::hasAnimationEffects() const
-{
-    ASSERT(!isUIThread());
-    return m_effectStack && m_effectStack->hasEffects();
-}
+    // FIXME: This doesn't really work yet.
+    m_effects->applyBackdropLayerEffects(layer(), host->animationCurrentTime());
 
-void RemoteLayerTreeNode::applyAnimatedEffectStack(Seconds currentTime)
-{
-    ASSERT(!isUIThread());
-
-    if (!m_effectStack)
-        return;
-
-    // The effect stack will have either primary layer effects or
-    // backdrop layer effects. We call both application methods.
-    m_effectStack->applyPrimaryLayerEffects(layer(), currentTime);
-    m_effectStack->applyBackdropLayerEffects(layer(), currentTime);
-
-    // We can clear the effect stack if it's empty, but the previous
-    // call to applyEffects() is important so that the base values
-    // were re-applied.
-    if (!m_effectStack->hasEffects())
-        m_effectStack = nullptr;
+    host->animationEffectStackAdded(*m_effects);
 }
 #endif
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
@@ -48,6 +48,7 @@ class PlatformWheelEvent;
 namespace WebKit {
 
 class NativeWebWheelEvent;
+class RemoteAcceleratedEffectStack;
 class RemoteLayerTreeHost;
 class RemoteScrollingCoordinatorTransaction;
 class RemoteScrollingTree;
@@ -129,6 +130,8 @@ public:
     virtual void scrollingTreeNodeDidEndScrollSnapping(WebCore::ScrollingNodeID) { }
     
     virtual void willCommitLayerAndScrollingTrees() { }
+    virtual void animationEffectStackAdded(Ref<RemoteAcceleratedEffectStack>) { }
+    virtual void animationEffectStackRemoved(Ref<RemoteAcceleratedEffectStack>) { }
     virtual void didCommitLayerAndScrollingTrees() { }
 
     String scrollingTreeAsText() const;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.h
@@ -30,7 +30,6 @@
 #if PLATFORM(IOS_FAMILY)
 
 OBJC_CLASS WKDisplayLinkHandler;
-OBJC_CLASS WKAnimationDisplayLinkHandler;
 
 namespace WebKit {
 
@@ -53,13 +52,6 @@ private:
     WKDisplayLinkHandler *displayLinkHandler();
 
     RetainPtr<WKDisplayLinkHandler> m_displayLinkHandler;
-
-#if ENABLE(THREADED_ANIMATION_RESOLUTION)
-    void animationsDidChangeOnNode(RemoteLayerTreeNode&) final;
-    void updateAnimations() final;
-    WKAnimationDisplayLinkHandler *animationDisplayLinkHandler();
-    RetainPtr<WKAnimationDisplayLinkHandler> m_animationDisplayLinkHandler;
-#endif
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.mm
@@ -175,68 +175,6 @@ static void* displayRefreshRateObservationContext = &displayRefreshRateObservati
 
 @end
 
-// FIXME: refactor this to have a single display link handler.
-@interface WKAnimationDisplayLinkHandler : NSObject {
-    WebKit::RemoteLayerTreeDrawingAreaProxy* _drawingAreaProxy;
-    CADisplayLink *_displayLink;
-}
-
-- (id)initWithDrawingAreaProxy:(WebKit::RemoteLayerTreeDrawingAreaProxy*)drawingAreaProxy;
-- (void)displayLinkFired:(CADisplayLink *)sender;
-- (void)invalidate;
-- (void)schedule;
-
-@end
-
-@implementation WKAnimationDisplayLinkHandler
-
-- (id)initWithDrawingAreaProxy:(WebKit::RemoteLayerTreeDrawingAreaProxy*)drawingAreaProxy
-{
-    ASSERT(WebCore::ScrollingThread::isCurrentThread());
-    if (self = [super init]) {
-        _drawingAreaProxy = drawingAreaProxy;
-        // Note that CADisplayLink retains its target (self), so a call to -invalidate is needed on teardown.
-        _displayLink = [CADisplayLink displayLinkWithTarget:self selector:@selector(displayLinkFired:)];
-        [_displayLink addToRunLoop:[NSRunLoop currentRunLoop] forMode:NSRunLoopCommonModes];
-        _displayLink.paused = YES;
-        _displayLink.preferredFramesPerSecond = (1.0 / _displayLink.maximumRefreshRate);
-    }
-    return self;
-}
-
-- (void)dealloc
-{
-    ASSERT(!_displayLink);
-    [super dealloc];
-}
-
-- (void)displayLinkFired:(CADisplayLink *)sender
-{
-    ASSERT(WebCore::ScrollingThread::isCurrentThread());
-    _drawingAreaProxy->updateAnimations();
-}
-
-- (void)invalidate
-{
-    ASSERT(isUIThread());
-    [_displayLink invalidate];
-    _displayLink = nullptr;
-}
-
-- (void)schedule
-{
-    ASSERT(WebCore::ScrollingThread::isCurrentThread());
-    _displayLink.paused = NO;
-}
-
-- (void)pause
-{
-    ASSERT(WebCore::ScrollingThread::isCurrentThread());
-    _displayLink.paused = YES;
-}
-
-@end
-
 namespace WebKit {
 using namespace IPC;
 using namespace WebCore;
@@ -249,7 +187,6 @@ RemoteLayerTreeDrawingAreaProxyIOS::RemoteLayerTreeDrawingAreaProxyIOS(WebPagePr
 RemoteLayerTreeDrawingAreaProxyIOS::~RemoteLayerTreeDrawingAreaProxyIOS()
 {
     [m_displayLinkHandler invalidate];
-    [m_animationDisplayLinkHandler invalidate];
 }
 
 std::unique_ptr<RemoteScrollingCoordinatorProxy> RemoteLayerTreeDrawingAreaProxyIOS::createScrollingCoordinatorProxy() const
@@ -288,36 +225,6 @@ std::optional<WebCore::FramesPerSecond> RemoteLayerTreeDrawingAreaProxyIOS::disp
 {
     return [displayLinkHandler() nominalFramesPerSecond];
 }
-
-#if ENABLE(THREADED_ANIMATION_RESOLUTION)
-void RemoteLayerTreeDrawingAreaProxyIOS::animationsDidChangeOnNode(RemoteLayerTreeNode& node)
-{
-    RemoteLayerTreeDrawingAreaProxy::animationsDidChangeOnNode(node);
-
-    ASSERT(isUIThread());
-    WebCore::ScrollingThread::dispatch([&] {
-        [animationDisplayLinkHandler() schedule];
-    });
-}
-
-void RemoteLayerTreeDrawingAreaProxyIOS::updateAnimations()
-{
-    RemoteLayerTreeDrawingAreaProxy::updateAnimations();
-
-    if (hasAnimatedNodes())
-        [animationDisplayLinkHandler() schedule];
-    else
-        [animationDisplayLinkHandler() pause];
-}
-
-WKAnimationDisplayLinkHandler *RemoteLayerTreeDrawingAreaProxyIOS::animationDisplayLinkHandler()
-{
-    ASSERT(WebCore::ScrollingThread::isCurrentThread());
-    if (!m_animationDisplayLinkHandler)
-        m_animationDisplayLinkHandler = adoptNS([[WKAnimationDisplayLinkHandler alloc] initWithDrawingAreaProxy:this]);
-    return m_animationDisplayLinkHandler.get();
-}
-#endif // ENABLE(THREADED_ANIMATION_RESOLUTION)
 
 } // namespace WebKit
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.h
@@ -84,12 +84,6 @@ private:
 
     WTF::MachSendRight createFence() override;
 
-#if ENABLE(THREADED_ANIMATION_RESOLUTION)
-    void animationsDidChangeOnNode(RemoteLayerTreeNode&) final;
-    void updateAnimations() final;
-    void scheduleAnimationUpdatesIfNecessary();
-#endif
-
     std::optional<WebCore::PlatformDisplayID> m_displayID; // Would be nice to make this non-optional, and ensure we always get one on creation.
     std::optional<WebCore::FramesPerSecond> m_displayNominalFramesPerSecond;
     WebCore::FramesPerSecond m_clientPreferredFramesPerSecond { WebCore::FullSpeedFramesPerSecond };
@@ -104,9 +98,6 @@ private:
     std::optional<double> m_transientZoomScale;
     std::optional<WebCore::FloatPoint> m_transientZoomOrigin;
 
-#if ENABLE(THREADED_ANIMATION_RESOLUTION)
-    bool m_shouldUpdateAnimationsWhenDisplayLinkFires { false };
-#endif
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h
@@ -88,6 +88,12 @@ public:
 
     void renderingUpdateComplete();
 
+    void lockForAnimationChanges() WTF_ACQUIRES_LOCK(m_animationsLock);
+    void unlockForAnimationChanges() WTF_RELEASES_LOCK(m_animationsLock);
+    void animationEffectStackAdded(Ref<RemoteAcceleratedEffectStack>);
+    void animationEffectStackRemoved(Ref<RemoteAcceleratedEffectStack>);
+    void updateAnimations();
+
 private:
     OptionSet<WebCore::WheelEventProcessingSteps> determineWheelEventProcessing(const WebCore::PlatformWheelEvent&, WebCore::RectEdges<bool> rubberBandableEdges);
 
@@ -159,6 +165,9 @@ private:
     MonotonicTime m_lastDisplayDidRefreshTime;
 
     std::unique_ptr<RunLoop::Timer> m_delayedRenderingUpdateDetectionTimer;
+
+    Lock m_animationsLock;
+    HashSet<Ref<RemoteAcceleratedEffectStack>> m_effects WTF_GUARDED_BY_LOCK(m_animationsLock);
 
 #if ENABLE(MOMENTUM_EVENT_DISPATCHER)
     std::unique_ptr<MomentumEventDispatcher> m_momentumEventDispatcher;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h
@@ -65,8 +65,10 @@ private:
     void windowScreenWillChange() override;
     void windowScreenDidChange(WebCore::PlatformDisplayID, std::optional<WebCore::FramesPerSecond>) override;
 
-    void willCommitLayerAndScrollingTrees() override;
-    void didCommitLayerAndScrollingTrees() override;
+    void willCommitLayerAndScrollingTrees() override WTF_IGNORES_THREAD_SAFETY_ANALYSIS;
+    void didCommitLayerAndScrollingTrees() override WTF_IGNORES_THREAD_SAFETY_ANALYSIS;
+    void animationEffectStackAdded(Ref<RemoteAcceleratedEffectStack>) override;
+    void animationEffectStackRemoved(Ref<RemoteAcceleratedEffectStack>) override;
     void applyScrollingTreeLayerPositionsAfterCommit() override;
 
 #if ENABLE(SCROLLING_THREAD)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm
@@ -113,7 +113,6 @@ void RemoteScrollingCoordinatorProxyMac::hasNodeWithAnimatedScrollChanged(bool h
     if (!drawingArea)
         return;
 
-    // FIXME: we also want to do this when animations are happening.
     drawingArea->setDisplayLinkWantsFullSpeedUpdates(hasAnimatedScrolls);
 #endif
 }
@@ -170,7 +169,7 @@ void RemoteScrollingCoordinatorProxyMac::connectStateNodeLayers(ScrollingStateTr
         case ScrollingNodeType::MainFrame:
         case ScrollingNodeType::Subframe: {
             ScrollingStateFrameScrollingNode& scrollingStateNode = downcast<ScrollingStateFrameScrollingNode>(*currNode);
-            
+
             if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::ScrollContainerLayer))
                 scrollingStateNode.setScrollContainerLayer(layerTreeHost.layerForID(PlatformLayerID { scrollingStateNode.scrollContainerLayer() }));
 
@@ -256,11 +255,23 @@ void RemoteScrollingCoordinatorProxyMac::windowScreenWillChange()
 void RemoteScrollingCoordinatorProxyMac::willCommitLayerAndScrollingTrees()
 {
     scrollingTree()->lockLayersForHitTesting();
+    m_wheelEventDispatcher->lockForAnimationChanges();
 }
 
 void RemoteScrollingCoordinatorProxyMac::didCommitLayerAndScrollingTrees()
 {
     scrollingTree()->unlockLayersForHitTesting();
+    m_wheelEventDispatcher->unlockForAnimationChanges();
+}
+
+void RemoteScrollingCoordinatorProxyMac::animationEffectStackAdded(Ref<RemoteAcceleratedEffectStack> effects)
+{
+    m_wheelEventDispatcher->animationEffectStackAdded(WTFMove(effects));
+}
+
+void RemoteScrollingCoordinatorProxyMac::animationEffectStackRemoved(Ref<RemoteAcceleratedEffectStack> effects)
+{
+    m_wheelEventDispatcher->animationEffectStackRemoved(WTFMove(effects));
 }
 
 void RemoteScrollingCoordinatorProxyMac::applyScrollingTreeLayerPositionsAfterCommit()


### PR DESCRIPTION
…o process on the animation thread, and make sure we're not trying

to access the RemoteLayerTreeDrawingProxy racily.

For MacOS, times the updating of animations to be straight after we've processed asynchronous scrolling.